### PR TITLE
fix: allow custom props on Button

### DIFF
--- a/components/ui/button.js
+++ b/components/ui/button.js
@@ -1,8 +1,20 @@
 import React from "react";
 
-export const Button = ({ children }) => {
+// Allow callers to pass additional properties such as click handlers or
+// custom classes. Default to a non-submitting button to avoid accidental
+// form submissions.
+export const Button = ({
+  children,
+  className = "",
+  type = "button",
+  ...props
+}) => {
   return (
-    <button className="inline-flex items-center px-4 py-2 bg-black text-white rounded hover:bg-gray-800 transition">
+    <button
+      type={type}
+      className={`inline-flex items-center px-4 py-2 bg-black text-white rounded hover:bg-gray-800 transition ${className}`}
+      {...props}
+    >
       {children}
     </button>
   );


### PR DESCRIPTION
## Summary
- allow passing className and other props to Button component
- default Button type to avoid unwanted form submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e58eb01b483289043962102bdd20c