### PR TITLE
Add image fallback for token frames

### DIFF
--- a/pages/f/[chain]/[address].js
+++ b/pages/f/[chain]/[address].js
@@ -21,7 +21,7 @@ export async function getServerSideProps(context) {
       if (token) {
         symbol = token.symbol;
         name = token.name;
-        image = token.image_url;
+        image = token.image_url || image; // Fallback to default OpenSea logo when token image missing
       }
     } catch (e) {
       console.error("Helius error", e);
@@ -33,7 +33,7 @@ export async function getServerSideProps(context) {
         const token = await cg.json();
         symbol = token.symbol.toUpperCase();
         name = token.name;
-        image = token.image.large;
+        image = token.image?.large || image; // Fallback to default OpenSea logo when token image missing
       }
     } catch (e) {
       console.error("CoinGecko error", e);


### PR DESCRIPTION
## Summary
- ensure token images fall back to the default OpenSea logo if unavailable
- use optional chaining when accessing token image data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688e5a3726388328855845c3ce7e5806